### PR TITLE
Add healthcheckPath, stage and change target group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ custom:
         - sg-000000000001
         - sg-000000000002
     repository: 000000000000.dkr.ecr.ap-southeast-2.amazonaws.com/containerless
+    stage: dev
     applications:
       hello-world
 ```
@@ -164,6 +165,7 @@ Fields:
   - src (if not provided will default to the application name)  
   - memory (defaults to 128)
   - url
+  - healthcheckPath (optional, default: `/`)
   - port
   - environment (optional array of key/values)
 
@@ -173,7 +175,7 @@ If url and port are omitted, the application will not be routed, and will be run
 
 Ports do not have to be unique, the system will dyanmically map ports to the docker container.
 
-You can use any valid AWS Application Load Balancer path pattern as the URL.
+You can use any valid AWS Application Load Balancer path pattern as the URL. You can also provide path for your application healthcheck (default `/`).
 
 Only one application can be mounted to the root url '/', because of the way in which the load balancer routes paths.
 Other applications will be routed based on a pattern, and you will need to remember to mount your application on that route as the load balancer forwards the whole url.
@@ -192,6 +194,7 @@ custom:
       hello-2:
         src: src-2
         url: /hello
+        healthcheckPath: /_health
         port: 3000
         environment:  
           - KEY: 'value'

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Required fields:
 
 A vpcId and one or more subnets in that VPC are required.
 If using an existing cluster, provide the VPC and subnets that the cluster has been created in.
+You can also use privateSubnets option (example below).
 
 If you need to define a VPC, a sample CloudFormation template is provided in `examples/vpc.cfn.yml`.
 You can use the
@@ -138,8 +139,13 @@ custom:
       subnets:
         - sg-000000000001
         - sg-000000000002
+      privateSubnets:
+        - sg-000000000001
+        - sg-000000000002
     repository: 000000000000.dkr.ecr.ap-southeast-2.amazonaws.com/containerless
 ```
+
+If you need you can also use privateSubnets option. Example below.
 
 ### Load Balancer ###
 

--- a/cluster.d.ts
+++ b/cluster.d.ts
@@ -1,6 +1,7 @@
 import { Resource } from './resource';
 export declare class Cluster implements Resource {
     amiIds: any;
+    name: string;
     subnets: string;
     vpcId: string;
     certificate: string;
@@ -15,7 +16,7 @@ export declare class Cluster implements Resource {
     private region;
     private size;
     private max_memory_threshold;
-    constructor(opts: any);
+    constructor(opts: any, clusterName: string);
     readonly defaultListenerName: string;
     readonly defaultTargetGroupName: string;
     requireVpcId(): void;
@@ -23,7 +24,7 @@ export declare class Cluster implements Resource {
     requireSubnets(): void;
     requireSecurityGroup(): void;
     ami(): any;
-    readonly name: string;
+    readonly clusterName: string;
     readonly id: string | {
         'Ref': string;
     };

--- a/cluster.d.ts
+++ b/cluster.d.ts
@@ -1,7 +1,7 @@
 import { Resource } from './resource';
 export declare class Cluster implements Resource {
     amiIds: any;
-    name: string;
+    clusterName: string;
     subnets: string;
     vpcId: string;
     certificate: string;
@@ -24,7 +24,7 @@ export declare class Cluster implements Resource {
     requireSubnets(): void;
     requireSecurityGroup(): void;
     ami(): any;
-    readonly clusterName: string;
+    readonly name: string;
     readonly id: string | {
         'Ref': string;
     };

--- a/cluster.d.ts
+++ b/cluster.d.ts
@@ -3,6 +3,7 @@ export declare class Cluster implements Resource {
     amiIds: any;
     clusterName: string;
     subnets: string;
+    privateSubnets: string;
     vpcId: string;
     certificate: string;
     protocol: Array<string>;

--- a/cluster.js
+++ b/cluster.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 var _ = require("lodash");
 var Cluster = (function () {
-    function Cluster(opts) {
+    function Cluster(opts, clusterName) {
         // http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI_launch_latest.html
         this.amiIds = {
             'us-east-1': 'ami-275ffe31',
@@ -36,6 +36,7 @@ var Cluster = (function () {
         this.subnets = opts.subnets || this.requireSubnets();
         this.protocol = _.castArray(opts.protocol) || ['HTTP'];
         this.certificate = opts.certificate;
+        this.name = clusterName;
         if (!this.certificate && _.includes(this.protocol, 'HTTPS')) {
             this.requireCertificate();
         }
@@ -71,9 +72,9 @@ var Cluster = (function () {
     Cluster.prototype.ami = function () {
         return this.amiIds[this.region];
     };
-    Object.defineProperty(Cluster.prototype, "name", {
+    Object.defineProperty(Cluster.prototype, "clusterName", {
         get: function () {
-            return 'Cluster';
+            return this.name;
         },
         enumerable: true,
         configurable: true
@@ -357,6 +358,10 @@ var Cluster = (function () {
                         {
                             'Key': 'Origin',
                             'Value': 'Containerless',
+                            'PropagateAtLaunch': true
+                        }, {
+                            'Key': 'Name',
+                            'Value': this.clusterName,
                             'PropagateAtLaunch': true
                         }
                     ]

--- a/cluster.js
+++ b/cluster.js
@@ -36,7 +36,7 @@ var Cluster = (function () {
         this.subnets = opts.subnets || this.requireSubnets();
         this.protocol = _.castArray(opts.protocol) || ['HTTP'];
         this.certificate = opts.certificate;
-        this.name = clusterName;
+        this.clusterName = clusterName;
         if (!this.certificate && _.includes(this.protocol, 'HTTPS')) {
             this.requireCertificate();
         }
@@ -72,9 +72,9 @@ var Cluster = (function () {
     Cluster.prototype.ami = function () {
         return this.amiIds[this.region];
     };
-    Object.defineProperty(Cluster.prototype, "clusterName", {
+    Object.defineProperty(Cluster.prototype, "name", {
         get: function () {
-            return this.name;
+            return this.clusterName;
         },
         enumerable: true,
         configurable: true
@@ -361,7 +361,7 @@ var Cluster = (function () {
                             'PropagateAtLaunch': true
                         }, {
                             'Key': 'Name',
-                            'Value': this.clusterName,
+                            'Value': this.name,
                             'PropagateAtLaunch': true
                         }
                     ]

--- a/cluster.js
+++ b/cluster.js
@@ -34,6 +34,9 @@ var Cluster = (function () {
         // we always need a vpc and at least one subnet
         this.vpcId = opts.vpcId || this.requireVpcId();
         this.subnets = opts.subnets || this.requireSubnets();
+        if (opts.privateSubnets) {
+            this.privateSubnets = opts.privateSubnets;
+        }
         this.protocol = _.castArray(opts.protocol) || ['HTTP'];
         this.certificate = opts.certificate;
         this.clusterName = clusterName;
@@ -353,7 +356,7 @@ var Cluster = (function () {
                     },
                     'MaxSize': this.max_size,
                     'MinSize': this.min_size,
-                    'VPCZoneIdentifier': this.subnets,
+                    'VPCZoneIdentifier': this.privateSubnets || this.subnets,
                     'Tags': [
                         {
                             'Key': 'Origin',

--- a/cluster.ts
+++ b/cluster.ts
@@ -19,6 +19,7 @@ export class Cluster implements Resource {
     'ca-central-1': 'ami-ee58e58a'
   }
 
+  public clusterName: string
   public subnets: string
   public vpcId: string
   public certificate: string
@@ -36,7 +37,7 @@ export class Cluster implements Resource {
   private size: number
   private max_memory_threshold: number
 
-  constructor(opts: any) {
+  constructor(opts: any, clusterName: string) {
     if (opts.id) {
       this._id = opts.id
       this._securityGroup = opts.security_group || this.requireSecurityGroup()
@@ -57,6 +58,7 @@ export class Cluster implements Resource {
     this.protocol = _.castArray(opts.protocol) || ['HTTP']
 
     this.certificate = opts.certificate
+    this.clusterName = clusterName
 
     if (!this.certificate && _.includes(this.protocol, 'HTTPS')) {
       this.requireCertificate()
@@ -94,7 +96,7 @@ export class Cluster implements Resource {
   }
 
   get name() {
-    return 'Cluster';
+    return this.clusterName;
   }
 
   get id() {
@@ -364,8 +366,12 @@ export class Cluster implements Resource {
           'VPCZoneIdentifier': this.subnets,
           'Tags': [
             {
-              'Key' : 'Origin',
+              'Key': 'Origin',
               'Value': 'Containerless',
+              'PropagateAtLaunch': true
+            }, {
+              'Key': 'Name',
+              'Value': this.name,
               'PropagateAtLaunch': true
             }
           ]

--- a/cluster.ts
+++ b/cluster.ts
@@ -21,6 +21,7 @@ export class Cluster implements Resource {
 
   public clusterName: string
   public subnets: string
+  public privateSubnets: string
   public vpcId: string
   public certificate: string
   public protocol: Array<string>
@@ -54,6 +55,10 @@ export class Cluster implements Resource {
     // we always need a vpc and at least one subnet
     this.vpcId = opts.vpcId || this.requireVpcId()
     this.subnets = opts.subnets || this.requireSubnets()
+
+    if (opts.privateSubnets) {
+      this.privateSubnets = opts.privateSubnets
+    }
 
     this.protocol = _.castArray(opts.protocol) || ['HTTP']
 
@@ -363,7 +368,7 @@ export class Cluster implements Resource {
           },
           'MaxSize': this.max_size,
           'MinSize': this.min_size,
-          'VPCZoneIdentifier': this.subnets,
+          'VPCZoneIdentifier': this.privateSubnets || this.subnets,
           'Tags': [
             {
               'Key': 'Origin',

--- a/factory.js
+++ b/factory.js
@@ -5,10 +5,11 @@ var elb_1 = require("./elb");
 var cluster_1 = require("./cluster");
 var service_1 = require("./service");
 function prepare(tag, opts) {
-    var cluster = new cluster_1.Cluster(opts.cluster);
+    var serviceStage = opts.stage ? opts.service + "-" + opts.stage : opts.service;
+    var cluster = new cluster_1.Cluster(opts.cluster, serviceStage);
     var elb = new elb_1.ELB(cluster);
     var applications = _.map(opts.applications, function (app, name) {
-        var o = _.merge({}, { service: opts.service, name: name, path: opts.path, repository: opts.repository, tag: tag }, app);
+        var o = _.merge({}, { service: opts.service, stage: opts.stage, name: name, path: opts.path, repository: opts.repository, tag: tag }, app);
         return new service_1.Service(cluster, o);
     });
     return _.concat(applications, cluster, elb);

--- a/factory.ts
+++ b/factory.ts
@@ -6,11 +6,13 @@ import { Resource } from './resource'
 import { Service } from './service'
 
 export function prepare(tag:string, opts:any): Array<Resource> {
-  let cluster = new Cluster(opts.cluster) ;
-  let elb = new ELB(cluster);
+  const serviceStage = opts.stage ? `${opts.service}-${opts.stage}` : opts.service;
 
-  let applications = _.map(opts.applications, (app:any, name: string) => {
-    let o = _.merge({}, { service: opts.service, name: name, path: opts.path, repository: opts.repository, tag: tag}, app);
+  const cluster = new Cluster(opts.cluster, serviceStage);
+  const elb = new ELB(cluster);
+
+  const applications = _.map(opts.applications, (app:any, name: string) => {
+    const o = _.merge({}, { service: opts.service, stage: opts.stage, name: name, path: opts.path, repository: opts.repository, tag: tag}, app);
     return new Service(cluster, o);
   });
 

--- a/listener.d.ts
+++ b/listener.d.ts
@@ -1,14 +1,15 @@
 import { Cluster } from './cluster';
 import { Resource } from './resource';
-import { Service } from './Service';
+import { Service } from './service';
 export declare class Listener implements Resource {
     service: Service;
     cluster: Cluster;
     priority: number;
     constructor(service: Service, cluster: Cluster);
     calculatePriority(): number;
-    readonly name: string;
+    readonly listenerName: string;
     readonly targetGroupName: string;
+    readonly healthcheckPath: string;
     required(): number | "";
     generate(): any;
     generateForProtocol(protocol: string): {

--- a/listener.d.ts
+++ b/listener.d.ts
@@ -7,7 +7,7 @@ export declare class Listener implements Resource {
     priority: number;
     constructor(service: Service, cluster: Cluster);
     calculatePriority(): number;
-    readonly listenerName: string;
+    readonly name: string;
     readonly targetGroupName: string;
     readonly healthcheckPath: string;
     required(): number | "";

--- a/listener.js
+++ b/listener.js
@@ -12,7 +12,7 @@ var Listener = (function () {
     Listener.prototype.calculatePriority = function () {
         return priority = priority + 1;
     };
-    Object.defineProperty(Listener.prototype, "listenerName", {
+    Object.defineProperty(Listener.prototype, "name", {
         get: function () {
             return this.service.name + "Listener";
         },

--- a/listener.js
+++ b/listener.js
@@ -12,7 +12,7 @@ var Listener = (function () {
     Listener.prototype.calculatePriority = function () {
         return priority = priority + 1;
     };
-    Object.defineProperty(Listener.prototype, "name", {
+    Object.defineProperty(Listener.prototype, "listenerName", {
         get: function () {
             return this.service.name + "Listener";
         },
@@ -22,6 +22,13 @@ var Listener = (function () {
     Object.defineProperty(Listener.prototype, "targetGroupName", {
         get: function () {
             return this.service.name + "Target";
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(Listener.prototype, "healthcheckPath", {
+        get: function () {
+            return "" + this.service.healthcheckPath;
         },
         enumerable: true,
         configurable: true
@@ -39,7 +46,7 @@ var Listener = (function () {
                 'Properties': {
                     'Name': this.targetGroupName,
                     'HealthCheckIntervalSeconds': 10,
-                    'HealthCheckPath': '/',
+                    'HealthCheckPath': this.healthcheckPath,
                     'HealthCheckProtocol': 'HTTP',
                     'HealthCheckTimeoutSeconds': 5,
                     'HealthyThresholdCount': 2,

--- a/listener.ts
+++ b/listener.ts
@@ -2,7 +2,7 @@ import * as _  from 'lodash';
 
 import { Cluster } from './cluster'
 import { Resource } from './resource'
-import { Service } from './Service'
+import { Service } from './service'
 
 // this is a terrible idea
 let priority = 0;
@@ -31,6 +31,10 @@ export class Listener implements Resource {
     return `${this.service.name}Target`;
   }
 
+  get healthcheckPath() {
+    return `${this.service.healthcheckPath}`;
+  }
+
   required() {
     return (this.service.url && this.service.port);
   }
@@ -44,7 +48,7 @@ export class Listener implements Resource {
         'Properties': {
           'Name': this.targetGroupName,
           'HealthCheckIntervalSeconds': 10,
-          'HealthCheckPath': '/',
+          'HealthCheckPath': this.healthcheckPath,
           'HealthCheckProtocol': 'HTTP',
           'HealthCheckTimeoutSeconds': 5,
           'HealthyThresholdCount': 2,

--- a/service.d.ts
+++ b/service.d.ts
@@ -1,10 +1,13 @@
 import { Cluster } from './cluster';
 import { Resource } from './resource';
 export declare class Service implements Resource {
+    private DEFAULT_HEALTHCHECK_PATH;
     port: number;
     url: string;
+    healthcheckPath: string;
     private _name;
     private _service;
+    private _stage;
     private cluster;
     private count;
     private environment;

--- a/service.js
+++ b/service.js
@@ -5,6 +5,7 @@ var listener_1 = require("./listener");
 var Service = (function () {
     function Service(cluster, opts) {
         var _this = this;
+        this.DEFAULT_HEALTHCHECK_PATH = '/';
         this.definition = function () {
             var definition = {
                 'Name': _this.name,
@@ -34,6 +35,7 @@ var Service = (function () {
         };
         this.cluster = cluster;
         this._service = opts.service;
+        this._stage = opts.stage;
         this._name = opts.name;
         this.tag = opts.tag || this.requireTag();
         this.repository = opts.repository || this.requireRepository();
@@ -49,6 +51,7 @@ var Service = (function () {
         });
         this.port = opts.port;
         this.url = opts.url;
+        this.healthcheckPath = opts.healthcheckPath || this.DEFAULT_HEALTHCHECK_PATH;
         if (this.port && !this.url)
             this.requireURL();
         if (this.url && !this.port)
@@ -111,7 +114,8 @@ var Service = (function () {
     });
     Object.defineProperty(Service.prototype, "name", {
         get: function () {
-            return _.chain(this._service + "-" + this._name).camelCase().upperFirst().value();
+            var serviceStage = this._stage ? this._service + "-" + this._stage : this._service;
+            return _.chain(serviceStage + "-" + this._name).camelCase().upperFirst().value();
         },
         enumerable: true,
         configurable: true

--- a/service.ts
+++ b/service.ts
@@ -6,11 +6,15 @@ import { Resource } from './resource'
 
 export class Service implements Resource {
 
+  private DEFAULT_HEALTHCHECK_PATH: string = '/'
+
   public port: number
   public url: string
+  public healthcheckPath: string
 
   private _name: string
   private _service: string
+  private _stage: string
 
   private cluster: Cluster
   private count: number
@@ -28,6 +32,7 @@ export class Service implements Resource {
     this.cluster = cluster;
 
     this._service = opts.service;
+    this._stage = opts.stage;
     this._name = opts.name;
     this.tag = opts.tag || this.requireTag();
     this.repository = opts.repository || this.requireRepository();
@@ -49,6 +54,7 @@ export class Service implements Resource {
 
     this.port = opts.port;
     this.url = opts.url;
+    this.healthcheckPath = opts.healthcheckPath || this.DEFAULT_HEALTHCHECK_PATH;
 
     if (this.port && !this.url) this.requireURL()
     if (this.url && !this.port) this.requirePort()
@@ -97,7 +103,9 @@ export class Service implements Resource {
   }
 
   get name() {
-    return _.chain(`${this._service}-${this._name}`).camelCase().upperFirst().value();
+    const serviceStage = this._stage ? `${this._service}-${this._stage}` : this._service;
+
+    return _.chain(`${serviceStage}-${this._name}`).camelCase().upperFirst().value();
   }
 
   generate() {

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -54,6 +54,11 @@ describe('create a new cluster with HTTPS', function () {
                     'subnet-b442c0d0',
                     'subnet-a2b967fb'
                 ],
+                privateSubnets: [
+                    'privateSubnet-12359e64',
+                    'privateSubnet-b442c0d0',
+                    'privateSubnet-a2b967fb'
+                ],
                 protocol: 'HTTPS',
                 certificate: 'arn:aws:acm:ap-southeast-2:000000000001:certificate/95898b22-e903-4d31-a50a-a0d4473aa077'
             };
@@ -70,6 +75,9 @@ describe('create a new cluster with HTTPS', function () {
         ClusterTest.prototype.sets_protocol = function () {
             chai_1.expect(this.cluster.protocol).to.eql(['HTTPS']);
         };
+        ClusterTest.prototype.sets_privateSubnets = function () {
+            chai_1.expect(this.cluster.privateSubnets).to.eql(this.opts.privateSubnets);
+        };
         return ClusterTest;
     }());
     __decorate([
@@ -81,6 +89,9 @@ describe('create a new cluster with HTTPS', function () {
     __decorate([
         mocha_typescript_1.test
     ], ClusterTest.prototype, "sets_protocol", null);
+    __decorate([
+        mocha_typescript_1.test
+    ], ClusterTest.prototype, "sets_privateSubnets", null);
     ClusterTest = __decorate([
         mocha_typescript_1.suite
     ], ClusterTest);

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -139,15 +139,19 @@ describe('create a new cluster with HTTP', function () {
                 ],
                 protocol: 'HTTP'
             };
+            this.clusterName = 'clsClusterName';
         }
         ClusterTest.prototype.before = function () {
-            this.cluster = new cluster_1.Cluster(this.opts);
+            this.cluster = new cluster_1.Cluster(this.opts, this.clusterName);
         };
         ClusterTest.prototype.id = function () {
             chai_1.expect(this.cluster.id).to.eql({ 'Ref': 'ClsCluster' });
         };
         ClusterTest.prototype.resources_not_empty = function () {
             chai_1.expect(this.cluster.generate()).to.not.be.empty;
+        };
+        ClusterTest.prototype.resources_cluster_name = function () {
+            chai_1.expect(this.cluster.name).to.eql('clsClusterName');
         };
         ClusterTest.prototype.sets_protocol = function () {
             chai_1.expect(this.cluster.protocol).to.eql(['HTTP']);
@@ -160,6 +164,9 @@ describe('create a new cluster with HTTP', function () {
     __decorate([
         mocha_typescript_1.test
     ], ClusterTest.prototype, "resources_not_empty", null);
+    __decorate([
+        mocha_typescript_1.test
+    ], ClusterTest.prototype, "resources_cluster_name", null);
     __decorate([
         mocha_typescript_1.test
     ], ClusterTest.prototype, "sets_protocol", null);

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -118,9 +118,12 @@ describe('create a new cluster with HTTP', () => {
       protocol: 'HTTP'
     }
 
+    clusterName = 'clsClusterName'
+
     cluster:Cluster
+
     before() {
-      this.cluster = new Cluster(this.opts);
+      this.cluster = new Cluster(this.opts, this.clusterName);
     }
 
     @test id() {
@@ -129,6 +132,10 @@ describe('create a new cluster with HTTP', () => {
 
     @test resources_not_empty(){
       expect(this.cluster.generate()).to.not.be.empty
+    }
+
+    @test resources_cluster_name(){
+      expect(this.cluster.name).to.eql('clsClusterName')
     }
 
     @test sets_protocol(){

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -47,6 +47,11 @@ describe('create a new cluster with HTTPS', () => {
         'subnet-b442c0d0',
         'subnet-a2b967fb'
       ],
+      privateSubnets: [
+        'privateSubnet-12359e64',
+        'privateSubnet-b442c0d0',
+        'privateSubnet-a2b967fb'
+      ],
       protocol: 'HTTPS',
       certificate: 'arn:aws:acm:ap-southeast-2:000000000001:certificate/95898b22-e903-4d31-a50a-a0d4473aa077'
     }
@@ -66,6 +71,10 @@ describe('create a new cluster with HTTPS', () => {
 
     @test sets_protocol(){
       expect(this.cluster.protocol).to.eql(['HTTPS'])
+    }
+
+    @test sets_privateSubnets(){
+      expect(this.cluster.privateSubnets).to.eql(this.opts.privateSubnets)
     }
 
   }

--- a/test/listener.test.js
+++ b/test/listener.test.js
@@ -30,6 +30,7 @@ describe('service with port and url', function () {
                 repository: 'blah/vtha',
                 tag: 'tag-1',
                 url: '/',
+                healthcheckPath: '/_health',
                 port: 1111
             };
         }
@@ -48,6 +49,10 @@ describe('service with port and url', function () {
             var result = _.get(this.resources, 'BlahVthaDevApp1Target.Type');
             chai_1.expect(result).to.eql('AWS::ElasticLoadBalancingV2::TargetGroup');
         };
+        ListenerTest.prototype.task_definition_resource_healthCheckPath = function () {
+            var result = _.get(this.resources, 'BlahVthaDevApp1Target.Properties.HealthCheckPath');
+            chai_1.expect(result).to.eql('/_health');
+        };
         ListenerTest.prototype.priority = function () {
             chai_1.expect(this.listener.priority).to.eql(2);
             var listener = new listener_1.Listener(this.service, this.cluster);
@@ -61,6 +66,9 @@ describe('service with port and url', function () {
     __decorate([
         mocha_typescript_1.test
     ], ListenerTest.prototype, "task_definition_resource_type", null);
+    __decorate([
+        mocha_typescript_1.test
+    ], ListenerTest.prototype, "task_definition_resource_healthCheckPath", null);
     __decorate([
         mocha_typescript_1.test
     ], ListenerTest.prototype, "priority", null);

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -28,6 +28,7 @@ describe('service with port and url', () => {
       repository: 'blah/vtha',
       tag: 'tag-1',
       url: '/',
+      healthcheckPath: '/_health',
       port: 1111
     }
 
@@ -53,6 +54,11 @@ describe('service with port and url', () => {
     @test task_definition_resource_type() {
       let result = _.get(this.resources, 'BlahVthaDevApp1Target.Type');
       expect(result).to.eql('AWS::ElasticLoadBalancingV2::TargetGroup');
+    }
+
+    @test task_definition_resource_healthCheckPath() {
+      let result = _.get(this.resources, 'BlahVthaDevApp1Target.Properties.HealthCheckPath');
+      expect(result).to.eql('/_health');
     }
 
     @test priority() {

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -44,6 +44,9 @@ describe('with an existing cluster and a load balanced container', function () {
         ServiceTest.prototype.service_name = function () {
             chai_1.expect(this.service.name).to.eql('BlahVthaDevApp1');
         };
+        ServiceTest.prototype.service_healthcheckPath = function () {
+            chai_1.expect(this.service.healthcheckPath).to.eql('/');
+        };
         ServiceTest.prototype.service_resource = function () {
             var result = _.get(this.resources, 'BlahVthaDevApp1.Type');
             chai_1.expect(result).to.eql('AWS::ECS::Service');
@@ -77,6 +80,9 @@ describe('with an existing cluster and a load balanced container', function () {
     __decorate([
         mocha_typescript_1.test
     ], ServiceTest.prototype, "service_name", null);
+    __decorate([
+        mocha_typescript_1.test
+    ], ServiceTest.prototype, "service_healthcheckPath", null);
     __decorate([
         mocha_typescript_1.test
     ], ServiceTest.prototype, "service_resource", null);
@@ -117,6 +123,7 @@ describe('new cluster and container without load balancer', function () {
                 service: 'blah-vtha-dev',
                 name: 'app-1',
                 repository: 'blah/vtha',
+                stage: 'production',
                 tag: 'tag-1',
             };
         }
@@ -125,8 +132,8 @@ describe('new cluster and container without load balancer', function () {
             this.service = new service_1.Service(cluster, this.opts);
             this.resources = this.service.generate();
         };
-        ServiceTest.prototype.service_name = function () {
-            chai_1.expect(this.service.name).to.eql('BlahVthaDevApp1');
+        ServiceTest.prototype.service_name_with_stage = function () {
+            chai_1.expect(this.service.name).to.eql('BlahVthaDevProductionApp1');
         };
         ServiceTest.prototype.service_load_balancers = function () {
             var result = _.get(this.resources, 'BlahVthaDevApp1.Properties.LoadBalancers');
@@ -144,7 +151,7 @@ describe('new cluster and container without load balancer', function () {
     }());
     __decorate([
         mocha_typescript_1.test
-    ], ServiceTest.prototype, "service_name", null);
+    ], ServiceTest.prototype, "service_name_with_stage", null);
     __decorate([
         mocha_typescript_1.test
     ], ServiceTest.prototype, "service_load_balancers", null);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -48,6 +48,10 @@ describe('with an existing cluster and a load balanced container', () => {
       expect(this.service.name).to.eql('BlahVthaDevApp1')
     }
 
+    @test service_healthcheckPath(){
+      expect(this.service.healthcheckPath).to.eql('/')
+    }
+
     @test service_resource(){
       let result = _.get(this.resources, 'BlahVthaDevApp1.Type');
       expect(result).to.eql('AWS::ECS::Service');
@@ -100,6 +104,7 @@ describe('new cluster and container without load balancer', () => {
       service: 'blah-vtha-dev',
       name: 'app-1',
       repository: 'blah/vtha',
+      stage: 'production',
       tag: 'tag-1',
     }
 
@@ -112,8 +117,8 @@ describe('new cluster and container without load balancer', () => {
       this.resources = this.service.generate()
     }
 
-    @test service_name(){
-      expect(this.service.name).to.eql('BlahVthaDevApp1')
+    @test service_name_with_stage(){
+      expect(this.service.name).to.eql('BlahVthaDevProductionApp1')
     }
 
     @test service_load_balancers(){


### PR DESCRIPTION
Few changes:
- `healthcheckPath` option for application if it's other then default `/`.
- Stage variable in `serverless.yml`, which is added to targetGroup. TargetGroup name constructed with only `service` and `name` of application makes impossible to have few stages.
- `clusterName` constructed from `service` and `stage` variables.

I'm open to any suggestions and feedback.

Best, 
Adrian