### PR TITLE
Removing @types dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
     "url": "https://github.com/Reckon-Limited/containerless"
   },
   "dependencies": {
-    "@types/aws-sdk": "^0.0.42",
-    "@types/chai": "^3.4.34",
-    "@types/es6-promise": "^0.0.32",
-    "@types/lodash": "^4.14.45",
     "aws-sdk": "^2.7.19",
     "chai": "^3.5.0",
     "lodash": "^4.17.3",


### PR DESCRIPTION
These cause issues with more recent versions of typescript, and removing them doesn't seem to cause any issues.

Specifically ran into an issue with the @types/es6-promise dependency when targeting ES6 with typescript and duplicate definitions of "Promise"